### PR TITLE
fix(snippet): when `description` field is nil

### DIFF
--- a/lua/phoenix/init.lua
+++ b/lua/phoenix/init.lua
@@ -602,8 +602,8 @@ function Snippet:get_completions(prefix)
         insertText = insert_text,
         documentation = {
           kind = 'markdown',
-          value = snippet_data.description
-            .. '\n\n```'
+          value = (snippet_data.description and snippet_data.description .. '\n\n' or '')
+            .. '```'
             .. ft
             .. '\n'
             .. parse_snippet(insert_text)


### PR DESCRIPTION
```text
Error executing vim.schedule lua callback: ....local/share/nvim/lazy/phoenix.nvim/lua/phoenix/init.lua:610: attempt to concatenate field 'description' (a nil value)
stack traceback:
	....local/share/nvim/lazy/phoenix.nvim/lua/phoenix/init.lua:610: in function 'get_completions'
	....local/share/nvim/lazy/phoenix.nvim/lua/phoenix/init.lua:810: in function <....local/share/nvim/lazy/phoenix.nvim/lua/phoenix/init.lua:735>
	....local/share/nvim/lazy/phoenix.nvim/lua/phoenix/init.lua:836: in function 'request'
	/usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:681: in function 'request'
	/usr/local/share/nvim/runtime/lua/vim/lsp/completion.lua:451: in function 'request'
	/usr/local/share/nvim/runtime/lua/vim/lsp/completion.lua:493: in function 'trigger'
	/usr/local/share/nvim/runtime/lua/vim/lsp/completion.lua:574: in function </usr/local/share/nvim/runtime/lua/vim/lsp/completion.lua:573>
```